### PR TITLE
Add barcode format selection

### DIFF
--- a/app/src/main/java/com/example/project_v1/MainActivity.kt
+++ b/app/src/main/java/com/example/project_v1/MainActivity.kt
@@ -31,10 +31,12 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -72,6 +74,7 @@ import com.google.mlkit.nl.entityextraction.Entity
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.barcode.BarcodeScanner
 import com.google.mlkit.vision.common.InputImage
 import android.graphics.Bitmap
 import com.squareup.moshi.Moshi
@@ -93,21 +96,6 @@ class MainActivity() : ComponentActivity() {
 ////////////////////// MODELE SIECI NEURONOWYCH
     private val mlExecutor = Executors.newSingleThreadExecutor()
 
-    val options = BarcodeScannerOptions.Builder()
-        .setBarcodeFormats(
-            Barcode.FORMAT_CODE_128,
-            Barcode.FORMAT_CODE_39,
-            Barcode.FORMAT_CODE_93,
-            Barcode.FORMAT_CODABAR,
-            Barcode.FORMAT_EAN_13,
-            Barcode.FORMAT_EAN_8,
-            Barcode.FORMAT_ITF,
-            Barcode.FORMAT_UPC_A,
-            Barcode.FORMAT_UPC_E,)
-        .setExecutor(mlExecutor)
-        .build()
-
-    val scanner = BarcodeScanning.getClient(options)
 
     private val viewModel: MainViewModel by viewModels {
         MainViewModelFactory(application)
@@ -125,7 +113,7 @@ class MainActivity() : ComponentActivity() {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         // uzależnienie modeli od cyklu życia aplikacji
-        lifecycle.addObserver(scanner)
+        // scanner initialized in CameraScreen
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -271,6 +259,19 @@ class MainActivity() : ComponentActivity() {
         val adapterSB = moshi.adapter(PostSendBarcodeResult::class.java)
         val adapterATI = moshi.adapter(PostAddToInventoryResult::class.java)
 
+        val lifecycleOwner = LocalLifecycleOwner.current
+        val scanner = remember(viewModel.barcodeFormats.value) {
+            val options = BarcodeScannerOptions.Builder()
+                .setBarcodeFormats(*viewModel.barcodeFormats.value.toIntArray())
+                .setExecutor(mlExecutor)
+                .build()
+            BarcodeScanning.getClient(options)
+        }
+        DisposableEffect(scanner) {
+            lifecycleOwner.lifecycle.addObserver(scanner)
+            onDispose { scanner.close() }
+        }
+
 
         ////////////////////////////////////////////////////////////
         ///////////////// MODELE SIECI NEURONOWYCH /////////////////
@@ -302,6 +303,7 @@ class MainActivity() : ComponentActivity() {
                             imageAnalysis = imageAnalysis,
                             preview = preview,
                             executor = cameraExecutor,
+                            scanner = scanner,
                             callable = { annotations ->
                                 dataToPrint = annotations.toString()
                             },
@@ -588,6 +590,23 @@ class MainActivity() : ComponentActivity() {
             var ip_address by remember { mutableStateOf(viewModel.ipSuffix.value) }
             var usernameTemp by remember { mutableStateOf(viewModel.appUsername.value) }
             var filenameTemp by remember { mutableStateOf(viewModel.appFilename.value) }
+            var selectedFormats by remember { mutableStateOf(viewModel.barcodeFormats.value.toMutableSet()) }
+
+            val allFormats = listOf(
+                Barcode.FORMAT_CODE_128 to "Code 128",
+                Barcode.FORMAT_CODE_39 to "Code 39",
+                Barcode.FORMAT_CODE_93 to "Code 93",
+                Barcode.FORMAT_CODABAR to "Codabar",
+                Barcode.FORMAT_DATA_MATRIX to "Data Matrix",
+                Barcode.FORMAT_EAN_13 to "EAN 13",
+                Barcode.FORMAT_EAN_8 to "EAN 8",
+                Barcode.FORMAT_ITF to "ITF",
+                Barcode.FORMAT_QR_CODE to "QR Code",
+                Barcode.FORMAT_UPC_A to "UPC A",
+                Barcode.FORMAT_UPC_E to "UPC E",
+                Barcode.FORMAT_PDF417 to "PDF417",
+                Barcode.FORMAT_AZTEC to "Aztec"
+            )
 
             Spacer(modifier = Modifier.height(160.dp))
             Text(text = "Wpisz adres IP (192.168.)xxx.xxx np. 0.186", color = Color.White)
@@ -617,11 +636,28 @@ class MainActivity() : ComponentActivity() {
                 modifier = modifier
             )
             Spacer(modifier = Modifier.height(16.dp))
+            Text(text = "Typy kodów do wykrycia", color = Color.White)
+            Column {
+                allFormats.forEach { (format, label) ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(
+                            checked = selectedFormats.contains(format),
+                            onCheckedChange = { checked ->
+                                selectedFormats = selectedFormats.toMutableSet().apply {
+                                    if (checked) add(format) else remove(format)
+                                }
+                            }
+                        )
+                        Text(label, color = Color.White)
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = { onClick(str.main.name) }) {
                 Text(text = "Powrót do ekranu głównego")
             }
 
-            viewModel.updateSettings(ip_address, usernameTemp, filenameTemp)
+            viewModel.updateSettings(ip_address, usernameTemp, filenameTemp, selectedFormats)
 
             Spacer(modifier = Modifier.height(16.dp))
             Text(text = "Obecnie wybrany adres IP ${viewModel.baseURL.value}" , color = Color.White)
@@ -710,6 +746,7 @@ class MainActivity() : ComponentActivity() {
         imageAnalysis: ImageAnalysis,
         preview: Preview,
         executor: Executor,
+        scanner: BarcodeScanner,
         callable: (String) -> Unit,
         modifier: Modifier = Modifier
     ) {

--- a/app/src/main/java/com/example/project_v1/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/example/project_v1/data/repository/SettingsRepository.kt
@@ -1,24 +1,33 @@
 package com.example.project_v1.data.repository
 
 import android.content.Context
+import com.google.mlkit.vision.barcode.common.Barcode
 
 class SettingsRepository(context: Context) {
     private val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
 
-    data class Settings(val ipSuffix: String, val username: String, val filename: String)
+    data class Settings(
+        val ipSuffix: String,
+        val username: String,
+        val filename: String,
+        val barcodeFormats: Set<Int>
+    )
 
     fun loadSettings(): Settings {
         val ip = prefs.getString(KEY_IP, DEFAULT_IP) ?: DEFAULT_IP
         val user = prefs.getString(KEY_USER, DEFAULT_USER) ?: DEFAULT_USER
         val file = prefs.getString(KEY_FILE, DEFAULT_FILE) ?: DEFAULT_FILE
-        return Settings(ip, user, file)
+        val formatsStr = prefs.getStringSet(KEY_BARCODES, DEFAULT_BARCODES_STR) ?: DEFAULT_BARCODES_STR
+        val formats = formatsStr.mapNotNull { it.toIntOrNull() }.toSet()
+        return Settings(ip, user, file, if (formats.isEmpty()) DEFAULT_BARCODES else formats)
     }
 
-    fun saveSettings(ipSuffix: String, username: String, filename: String) {
+    fun saveSettings(ipSuffix: String, username: String, filename: String, barcodeFormats: Set<Int>) {
         prefs.edit()
             .putString(KEY_IP, ipSuffix)
             .putString(KEY_USER, username)
             .putString(KEY_FILE, filename)
+            .putStringSet(KEY_BARCODES, barcodeFormats.map { it.toString() }.toSet())
             .apply()
     }
 
@@ -27,6 +36,24 @@ class SettingsRepository(context: Context) {
         private const val KEY_IP = "ip_suffix"
         private const val KEY_USER = "username"
         private const val KEY_FILE = "filename"
+        private const val KEY_BARCODES = "barcode_formats"
+
+        val DEFAULT_BARCODES = setOf(
+            Barcode.FORMAT_CODE_128,
+            Barcode.FORMAT_CODE_39,
+            Barcode.FORMAT_CODE_93,
+            Barcode.FORMAT_CODABAR,
+            Barcode.FORMAT_DATA_MATRIX,
+            Barcode.FORMAT_EAN_13,
+            Barcode.FORMAT_EAN_8,
+            Barcode.FORMAT_ITF,
+            Barcode.FORMAT_QR_CODE,
+            Barcode.FORMAT_UPC_A,
+            Barcode.FORMAT_UPC_E,
+            Barcode.FORMAT_PDF417,
+            Barcode.FORMAT_AZTEC
+        )
+        private val DEFAULT_BARCODES_STR = DEFAULT_BARCODES.map { it.toString() }.toSet()
 
         const val DEFAULT_IP = "0.173"
         const val DEFAULT_USER = "Brak"

--- a/app/src/main/java/com/example/project_v1/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/project_v1/viewmodel/MainViewModel.kt
@@ -21,26 +21,29 @@ class MainViewModel(
         private set
     var appFilename = mutableStateOf(SettingsRepository.DEFAULT_FILE)
         private set
+    var barcodeFormats = mutableStateOf(SettingsRepository.DEFAULT_BARCODES)
+        private set
     var settingDone = mutableStateOf(0)
         private set
 
     init {
         val saved = settingsRepository.loadSettings()
-        applySettings(saved.ipSuffix, saved.username, saved.filename, save = false)
+        applySettings(saved.ipSuffix, saved.username, saved.filename, saved.barcodeFormats, save = false)
     }
 
-    fun updateSettings(ip: String, username: String, filename: String) {
-        applySettings(ip, username, filename, save = true)
+    fun updateSettings(ip: String, username: String, filename: String, barcodes: Set<Int>) {
+        applySettings(ip, username, filename, barcodes, save = true)
     }
 
-    private fun applySettings(ip: String, username: String, filename: String, save: Boolean) {
+    private fun applySettings(ip: String, username: String, filename: String, barcodes: Set<Int>, save: Boolean) {
         ipSuffix.value = ip
         baseURL.value = "http://192.168.${ip}:3000/"
         appUsername.value = username
         appFilename.value = filename
+        barcodeFormats.value = barcodes
         settingDone.value = 1
         if (save) {
-            settingsRepository.saveSettings(ip, username, filename)
+            settingsRepository.saveSettings(ip, username, filename, barcodes)
         }
     }
 


### PR DESCRIPTION
## Summary
- persist barcode scanning formats
- expose formats in `SettingsRepository` and `MainViewModel`
- let users choose barcode formats in the Settings screen
- build ML Kit scanner using chosen formats

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e303ae9208328bd55e09010f95f2e